### PR TITLE
add noop legacy output for nteract-scrapbook

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,6 +6,12 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
 zip_keys:
 - - cdt_name
   - docker_image

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        * )
+            echo "$1";;
+    esac
+}
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+    esac
+}

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+startgroup "Configure Docker"
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -65,7 +69,9 @@ DOCKER_RUN_ARGS="${CONDA_FORGE_DOCKER_RUN_ARGS}"
 if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
+endgroup "Configure Docker"
 
+startgroup "Start Docker"
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About scrapbook
-===============
+About scrapbook-build
+=====================
 
 Home: https://github.com/nteract/scrapbook
 
@@ -33,27 +33,28 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-nteract--scrapbook-green.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nteract-scrapbook.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nteract-scrapbook.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nteract-scrapbook.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-scrapbook-green.svg)](https://anaconda.org/conda-forge/scrapbook) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scrapbook.svg)](https://anaconda.org/conda-forge/scrapbook) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scrapbook.svg)](https://anaconda.org/conda-forge/scrapbook) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/scrapbook.svg)](https://anaconda.org/conda-forge/scrapbook) |
 
-Installing scrapbook
-====================
+Installing scrapbook-build
+==========================
 
-Installing `scrapbook` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `scrapbook-build` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `scrapbook` can be installed with:
+Once the `conda-forge` channel has been enabled, `nteract-scrapbook, scrapbook` can be installed with:
 
 ```
-conda install scrapbook
+conda install nteract-scrapbook scrapbook
 ```
 
-It is possible to list all of the versions of `scrapbook` available on your platform with:
+It is possible to list all of the versions of `nteract-scrapbook` available on your platform with:
 
 ```
-conda search scrapbook --channel conda-forge
+conda search nteract-scrapbook --channel conda-forge
 ```
 
 
@@ -95,26 +96,26 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating scrapbook-feedstock
-============================
+Updating scrapbook-build-feedstock
+==================================
 
-If you would like to improve the scrapbook recipe or build a new
+If you would like to improve the scrapbook-build recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/scrapbook-feedstock are
+Note that all branches in the conda-forge/scrapbook-build-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,46 +1,76 @@
-{% set name = "scrapbook" %}
 {% set version = "0.5.0" %}
+{% set build_number = "1" %}
+{% set python_version = ">=3.5" %}
 
 package:
-  name: {{ name|lower }}
+  name: scrapbook-build
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/scrapbook/scrapbook-{{ version }}.tar.gz
   sha256: 6875bc804c3278a00544dbc232cb96e7cf8a563c36e02b17dcae329d05470cd0
 
 build:
   noarch: python
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: {{ build_number }}
 
 requirements:
   host:
-    - python >=3.5
+    - python {{ python_version }}
     - pip
   run:
-    - ipython
-    - jsonschema
-    - pandas
-    - papermill
-    - pyarrow
-    - python >=3.5
+    - python {{ python_version }}
 
 test:
-  requires:
-    - coverage
-    - ipython
-    - mock
-    - pip
-    - pytest >=4.1
-    - pytest-cov >=2.6.1
-    - pytest-env >=0.6.2
-    - pytest-mock >=1.10
-  imports:
-    - scrapbook
   commands:
-    - python -m pytest --pyargs scrapbook --cov scrapbook -v
-    - python -m pip check
+    - echo "tests in subpackages"
+
+outputs:
+  - name: scrapbook
+    build:
+      noarch: python
+      number: {{ build_number }}
+      script: python -m pip install . -vv --no-deps
+    requirements:
+      host:
+        - python {{ python_version }}
+        - pip
+      run:
+        - ipython
+        - jsonschema
+        - pandas
+        - papermill
+        - pyarrow
+        - python {{ python_version }}
+    test:
+      requires:
+        - coverage
+        - ipython
+        - mock
+        - pip
+        - pytest >=4.1
+        - pytest-cov >=2.6.1
+        - pytest-env >=0.6.2
+        - pytest-mock >=1.10
+      imports:
+        - scrapbook
+      commands:
+        - pip check
+        - pytest -v --pyargs scrapbook --cov scrapbook --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under 96
+
+  - name: nteract-scrapbook
+    build:
+      noarch: python
+      number: {{ build_number }}
+    requirements:
+      host:
+        - python {{ python_version }}
+      run:
+        - python {{ python_version }}
+        - scrapbook =={{ version }}
+    test:
+      imports:
+        - scrapbook
 
 about:
   home: https://github.com/nteract/scrapbook


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- this adds multiple `outputs`, with an `nteract-scrapbook` that exists only to depend on `scrapbook` at the exact version (though build numbers won't be consulted)
- @mseal if this is a **terrible idea**, please let me know... dagster might be the only downstream, so maybe this isn't a big deal, but renaming is always awkward