### PR TITLE
revert #6, remove nteract-scrapbook

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,12 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.8.* *_cpython
 zip_keys:
 - - cdt_name
   - docker_image

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-nteract--scrapbook-green.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nteract-scrapbook.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nteract-scrapbook.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nteract-scrapbook.svg)](https://anaconda.org/conda-forge/nteract-scrapbook) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-scrapbook-green.svg)](https://anaconda.org/conda-forge/scrapbook) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scrapbook.svg)](https://anaconda.org/conda-forge/scrapbook) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scrapbook.svg)](https://anaconda.org/conda-forge/scrapbook) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/scrapbook.svg)](https://anaconda.org/conda-forge/scrapbook) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-scrapbook--build-green.svg)](https://anaconda.org/conda-forge/scrapbook-build) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/scrapbook-build.svg)](https://anaconda.org/conda-forge/scrapbook-build) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/scrapbook-build.svg)](https://anaconda.org/conda-forge/scrapbook-build) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/scrapbook-build.svg)](https://anaconda.org/conda-forge/scrapbook-build) |
 
 Installing scrapbook-build
 ==========================
@@ -45,16 +44,16 @@ Installing `scrapbook-build` from the `conda-forge` channel can be achieved by a
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `nteract-scrapbook, scrapbook` can be installed with:
+Once the `conda-forge` channel has been enabled, `scrapbook-build` can be installed with:
 
 ```
-conda install nteract-scrapbook scrapbook
+conda install scrapbook-build
 ```
 
-It is possible to list all of the versions of `nteract-scrapbook` available on your platform with:
+It is possible to list all of the versions of `scrapbook-build` available on your platform with:
 
 ```
-conda search nteract-scrapbook --channel conda-forge
+conda search scrapbook-build --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,4 @@
 {% set version = "0.5.0" %}
-{% set build_number = "1" %}
-{% set python_version = ">=3.5" %}
 
 package:
   name: scrapbook-build
@@ -12,65 +10,36 @@ source:
 
 build:
   noarch: python
-  number: {{ build_number }}
+  number: 2
+  script: python -m pip install . -vv --no-deps
 
 requirements:
   host:
-    - python {{ python_version }}
     - pip
+    - python >=3.5
   run:
-    - python {{ python_version }}
+    - ipython
+    - jsonschema
+    - pandas
+    - papermill
+    - pyarrow
+    - python >=3.5
 
 test:
+  requires:
+    - coverage
+    - ipython
+    - mock
+    - pip
+    - pytest >=4.1
+    - pytest-cov >=2.6.1
+    - pytest-env >=0.6.2
+    - pytest-mock >=1.10
+  imports:
+    - scrapbook
   commands:
-    - echo "tests in subpackages"
-
-outputs:
-  - name: scrapbook
-    build:
-      noarch: python
-      number: {{ build_number }}
-      script: python -m pip install . -vv --no-deps
-    requirements:
-      host:
-        - python {{ python_version }}
-        - pip
-      run:
-        - ipython
-        - jsonschema
-        - pandas
-        - papermill
-        - pyarrow
-        - python {{ python_version }}
-    test:
-      requires:
-        - coverage
-        - ipython
-        - mock
-        - pip
-        - pytest >=4.1
-        - pytest-cov >=2.6.1
-        - pytest-env >=0.6.2
-        - pytest-mock >=1.10
-      imports:
-        - scrapbook
-      commands:
-        - pip check
-        - pytest -v --pyargs scrapbook --cov scrapbook --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under 96
-
-  - name: nteract-scrapbook
-    build:
-      noarch: python
-      number: {{ build_number }}
-    requirements:
-      host:
-        - python {{ python_version }}
-      run:
-        - python {{ python_version }}
-        - scrapbook =={{ version }}
-    test:
-      imports:
-        - scrapbook
+    - pip check
+    - pytest -v --pyargs scrapbook --cov scrapbook --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under 96
 
 about:
   home: https://github.com/nteract/scrapbook


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Notes
- revert #6
- fix #7 

At some time in the future, we might be able to figure out a usable approach to this kind of renaming, but for now not worth the hassle. 

Next steps:
- `admin-request` to mark `noarch/nteract-scrapbook-0.5.0-pyh44b312d_1.tar.bz2` broken